### PR TITLE
Busquem el fitxer de configuració

### DIFF
--- a/spawn_oop/__init__.py
+++ b/spawn_oop/__init__.py
@@ -92,6 +92,16 @@ class spawn(object):
                             '--database=%s' % cursor.dbname,
                             '--logfile=%s' % tempfile.mkstemp()[1],
                             '--pidfile=%s' % os.devnull]
+                # Try to check if we have a conf file
+                conf_found = [x for x in command if x.startswith('--conf=')]
+                # If we don't found a conf file try to check if exists in
+                # os env.
+                # This is usefull spawning openerp instances from process that
+                # aren't openerp instances. As a OORQ
+                if not conf_found:
+                    conf_path = os.getenv('OPENERP_CONF', False)
+                    if conf_path:
+                        command += ['--conf=%s' % os.getenv('OPENERP_CONF')]
 
                 start = datetime.now()
                 logger.notifyChannel('spawn_oop', netsvc.LOG_INFO, 'Spawned '


### PR DESCRIPTION
Si fem `spawn` des de processos que no són el propi servidor
ERP, com per exemple un worker d'rq no vindrà el paràmetre del
fitxer de configuració. Amb aquest canvi permetem que es pugui
especificar a través de la variable d'entorn OPENERP_CONF
