### PR TITLE
FIX when config interface is empty string

### DIFF
--- a/spawn_oop/__init__.py
+++ b/spawn_oop/__init__.py
@@ -48,6 +48,8 @@ class spawn(object):
     @staticmethod
     def get_uri(child_port):
         interface = config.get('interface', 'localhost')
+        if not interface:
+            interface = 'localhost'
         if config['secure']:
             uri = 'https://{0}'.format(interface)
         else:


### PR DESCRIPTION
In some config files there are interface config without anything and then values of `interface` is an empty string.  In this case it assumes that interface is `localhost`